### PR TITLE
feat: optionally only create private zone DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ The name of the stack to generate DNS entries for.
 
 The desired domain name for the DNS entries.
 
+#### `privateOnly` (`boolean`, _optional_)
+
+`true` if only private zone DNS records should be created, `false` if both public and private
+records should be created. Defaults to `false`.
+
 #### `TTL` (`number`, _optional_)
 
 The time-to-live for the DNS entries (not required for load balancers)
@@ -98,6 +103,11 @@ The name of the stack to generate DNS entries for.
 #### `DNSName` (`string`, _required_)
 
 The desired domain name for the DNS entries.
+
+#### `privateOnly` (`boolean`, _optional_)
+
+`true` if only private zone DNS records should be created, `false` if both public and private
+records should be created. Defaults to `false`.
 
 #### `TTL` (`number`, _optional_)
 
@@ -164,18 +174,19 @@ If there are multiple EC2 Instances and/or load balancers output by the stack, t
 ### Usage
 
 ```
-cfroute53 upsert <stack name> <domain name> --region <AWS region> [--ttl <time to live>]
+cfroute53 upsert <stack name> <domain name> --region <AWS region> [--private-only] [--ttl <time to live>]
 ```
 
 ### Options
 
 ```
---version      Show version number                                   [boolean]
---help         Show help                                             [boolean]
---ttl          the time-to-live for the record                        [number]
--c, --comment  a comment for the change                               [string]
---region       the AWS region                                         [string]
--q, --quiet    suppress output                                       [boolean]
--v, --verbose  enable verbose output                                 [boolean]
--y, --yes      don't ask for confirmation                            [boolean]
+--version           Show version number                              [boolean]
+--help              Show help                                        [boolean]
+-p, --private-only  only create private zone DNS records             [boolean]
+--ttl               the time-to-live for the record                   [number]
+-c, --comment       a comment for the change                          [string]
+--region            the AWS region                                    [string]
+-q, --quiet         suppress output                                  [boolean]
+-v, --verbose       enable verbose output                            [boolean]
+-y, --yes           don't ask for confirmation                       [boolean]
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,11 @@ yargs
         .usage(
           '$0 upsert <stack name> <domain name> --region <AWS region> [--ttl <time to live>]'
         )
+        .option('p', {
+          alias: 'private-only',
+          type: 'boolean',
+          describe: 'only create private DNS records',
+        })
         .option('ttl', {
           type: 'number',
           describe: 'the time-to-live for the record',
@@ -48,7 +53,15 @@ yargs
         })
     },
     async function (argv: any) {
-      const { ttl: TTL, comment: Comment, region, quiet, verbose, yes } = argv
+      const {
+        p: privateOnly,
+        ttl: TTL,
+        comment: Comment,
+        region,
+        quiet,
+        verbose,
+        yes,
+      } = argv
       const args = argv._.slice(1)
 
       const StackName = args.find(
@@ -71,6 +84,7 @@ yargs
       const recordSets = await genRecordSetsForStack({
         StackName,
         DNSName,
+        privateOnly,
         TTL,
         region,
         log,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,7 @@ export function genRecordSetsForECSInstance(options: {
   InstanceId: string
   DNSName: string
   EC2?: AWS.EC2 | null
+  privateOnly?: boolean | null
   TTL?: number | null
   region?: string | null
   awsConfig?: AWS.ConfigurationOptions | null
@@ -23,6 +24,7 @@ export function genRecordSetsForECSInstance(options: {
 export function genRecordSetsForLoadBalancer(options: {
   LoadBalancerArn: string
   DNSName: string
+  privateOnly?: boolean | null
   ELBv2?: AWS.ELBv2 | null
   log?: null | ((...args: any) => any)
   region?: string | null
@@ -33,6 +35,7 @@ export function genRecordSetsForLoadBalancer(options: {
 export function genRecordSetsForStackOutputs(options: {
   Outputs: Array<StackOutput>
   DNSName: string
+  privateOnly?: boolean | null
   TTL?: number | null
   EC2?: AWS.EC2 | null
   ELBv2?: AWS.ELBv2 | null
@@ -45,6 +48,7 @@ export function genRecordSetsForStackOutputs(options: {
 export type GenRecordSetsForStackOptions = {
   StackName: string
   DNSName: string
+  privateOnly?: boolean | null
   TTL?: number | null
   interactive?: boolean | null
   CloudFormation?: AWS.CloudFormation | null


### PR DESCRIPTION
I want to change the notifications API for both JCore and KES to be internal-only. This PR adds a privateOnly option that causes only private zone DNS records to be created.